### PR TITLE
[issues-332] db を使ったときのアセンブル速度について

### DIFF
--- a/AILZ80ASM/OperationItems/OperationItemData.cs
+++ b/AILZ80ASM/OperationItems/OperationItemData.cs
@@ -36,9 +36,6 @@ namespace AILZ80ASM.OperationItems
         private static readonly Regex CompiledRegexPatternDataFunction = new Regex(
             RegexPatternDataFunction, RegexOptions.Compiled | RegexOptions.Singleline | RegexOptions.IgnoreCase
         );
-        private static readonly Regex RegexPatternDataFunction2 = new Regex(
-            RegexPatternDataFunction, RegexOptions.Compiled
-        );
 
         private static readonly string RegexPatternDataOP = @"(?<op1>^\S+)?\s*(?<op2>.+)*";
         private static readonly Regex CompiledRegexPatternDataOP = new Regex(
@@ -109,7 +106,7 @@ namespace AILZ80ASM.OperationItems
                     }
 
                 }
-                else if (RegexPatternDataFunction2.IsMatch(item.Value))
+                else if (CompiledRegexPatternDataFunction.IsMatch(item.Value))
                 {
                     ValueList.AddRange(DBDW_Function(item.Value, lineDetailExpansionItemOperation, AsmLoad).Select(m => new DataValue { DataValueType = DataValueTypeEnum.StringValue, StringValue = m }));
                 }
@@ -276,7 +273,7 @@ namespace AILZ80ASM.OperationItems
                 {
                     //ループの展開
                     var tmpOperation = Regex.Replace(operation, $"\\b{variableName}\\b", $"{currentValue}", RegexOptions.Singleline | RegexOptions.IgnoreCase);
-                    if (RegexPatternDataFunction2.IsMatch(tmpOperation))
+                    if (CompiledRegexPatternDataFunction.IsMatch(tmpOperation))
                     {
                         returnValues.AddRange(DBDW_Function(tmpOperation, lineDetailExpansionItemOperation, asmLoad));
                     }


### PR DESCRIPTION
# 概要
ueno1969さんから、アセンブルの速度が遅いとの指摘をいただきました。また、正規表現をCompiledオプションを使用して高速化する対応を行ったPRが提出されました。AILightがこのPRをレビューしたところ、元のソースコードにおいて、正規表現オプションの指定漏れがあったことが判明したため、修正対応を行いました。

# Issue
https://github.com/AILight/AILZ80ASM/issues/332

# PR
https://github.com/AILight/AILZ80ASM/pull/335

# 修正内容
RegexOptions.Singleline | RegexOptions.IgnoreCaseのつけ忘れ対応

レビューをよろしくお願いいたします。